### PR TITLE
fix: allow internal modules for next

### DIFF
--- a/src/next.js
+++ b/src/next.js
@@ -2,4 +2,12 @@ module.exports = {
   extends: ['./react.js', 'next/core-web-vitals'],
   plugins: ['@next/eslint-plugin-next'],
   parser: '@typescript-eslint/parser',
+  rules: {
+    'import/no-internal-modules': [
+      'error',
+      {
+        allow: ['next/*'],
+      },
+    ],
+  },
 };

--- a/src/next.js
+++ b/src/next.js
@@ -2,6 +2,17 @@ module.exports = {
   extends: ['./react.js', 'next/core-web-vitals'],
   plugins: ['@next/eslint-plugin-next'],
   parser: '@typescript-eslint/parser',
+  overrides: [
+    {
+      files: [
+        "**/__tests__/pages/**/*.test.tsx",
+      ],
+      rules: {
+        "jest/valid-expect": "off",
+        "jest/expect-expect": "off",
+      },
+    },
+  ],
   rules: {
     'import/no-internal-modules': [
       'error',

--- a/src/next.js
+++ b/src/next.js
@@ -4,12 +4,10 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   overrides: [
     {
-      files: [
-        "**/__tests__/pages/**/*.test.tsx",
-      ],
+      files: ['**/__tests__/pages/**/*.test.tsx'],
       rules: {
-        "jest/valid-expect": "off",
-        "jest/expect-expect": "off",
+        'jest/valid-expect': 'off',
+        'jest/expect-expect': 'off',
       },
     },
   ],


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Allow internal modules for next.js
