### PR TITLE
fix: ignore dist directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ module.exports = {
     },
   },
   plugins: ['prettier', 'import', 'jest', 'unicorn'],
+  ignorePatterns: ['dist'],
   overrides: [
     {
       files: ['*.ts', '*.js'],


### PR DESCRIPTION
Makes sure `dist` directory is ignored so that built packages are not listed.

**Before:**
```
npm run lint  418.82s user 4.16s system 101% cpu 6:57.23 total
```

**After:** 
```
npm run lint  15.96s user 1.30s system 114% cpu 15.019 total
```