### PR TITLE
fix: remove no-shadow rule in favor of typescript/no-shadow

### DIFF
--- a/src/__tests__/bad/ts/shadow.ts
+++ b/src/__tests__/bad/ts/shadow.ts
@@ -1,2 +1,0 @@
-const baz = 1;
-const maz = (baz) => baz;

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -8,19 +8,19 @@ const testConfigs = [
   {
     eslintFilePath: `${testDir}/.eslintrc.js`,
     good: 0,
-    bad: 21,
+    bad: 17,
     filePattern: '{js,ts}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.react.js`,
     good: 6,
-    bad: 33,
+    bad: 29,
     filePattern: '{js,ts,jsx,tsx}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.next.js`,
     good: 0,
-    bad: 33,
+    bad: 29,
     filePattern: '{js,ts,jsx,tsx}',
   },
 ];

--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,5 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
-    'no-shadow': 'error',
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,12 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['*.ts'],
+      rules: {
+        'no-shadow': 'off',
+      },
+    },
   ],
   rules: {
     'no-console': 'error',
@@ -135,5 +141,6 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
+    'no-shadow': 'error',
   },
 };


### PR DESCRIPTION
References [DM-599](https://autoricardo.atlassian.net/browse/DM-599)

## Motivation and context

as per [typescript 4.0.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.0.0), no-shadow should be turned off in favor of @typescript-eslint/no-shadow. Using it marks exporting an enum as an error
