### PR TITLE
fix: exception for properties with quotes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,21 @@ module.exports = {
             selector: 'typeLike',
             format: ['PascalCase'],
           },
+          {
+            // Ignore properties that require quotes
+            selector: [
+              'classProperty',
+              'objectLiteralProperty',
+              'typeProperty',
+              'classMethod',
+              'objectLiteralMethod',
+              'typeMethod',
+              'accessor',
+              'enumMember',
+            ],
+            format: null,
+            modifiers: ['requiresQuotes'],
+          },
         ],
       },
     },


### PR DESCRIPTION
References [FE-76](https://autoricardo.atlassian.net/browse/FE-76)

## Motivation and context

Adds an exception to properties that are wrapped in a string. This removes the issue that we have with some chakra props:

```tsx
<Grid
          /* eslint-disable-next-line @typescript-eslint/naming-convention */
          columns={{ '2xs': 1, lg: 2 }}
          /* eslint-disable-next-line @typescript-eslint/naming-convention */
          spacing={{ '2xs': 'md', lg: '3xl' }}
        >
```

and API client:
```ts
interface ListingsClientConfiguration extends ClientConfiguration {
  // eslint-disable-next-line @typescript-eslint/naming-convention
  'listings/{listingId}': {
    get: () => ResponseType<never, Listing>;
  };
  // eslint-disable-next-line @typescript-eslint/naming-convention
  'listings/{listingId}/message-leads': {
    post: (
      request: RequestType<Partial<MessageLead>>
    ) => ResponseType<MessageLead>;
  };
}
```
## Before

Ignore needed

## After

No ignore needed anymore

## How to test

[Add a deep link and instructions how to verify the new behavior]
