### PR TITLE
fix: disable import no-internal-modules

### DIFF
--- a/src/__tests__/bad/js/internalModules.js
+++ b/src/__tests__/bad/js/internalModules.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line no-unused-vars
-import picka from '@next/eslint-plugin-next/lib/index';
+import promisify from 'agent-base/dist/src/promisify';

--- a/src/__tests__/bad/js/internalModules.js
+++ b/src/__tests__/bad/js/internalModules.js
@@ -1,2 +1,0 @@
-// eslint-disable-next-line no-unused-vars
-import picka from '@next/eslint-plugin-next/lib/index';

--- a/src/__tests__/bad/js/internalModules.js
+++ b/src/__tests__/bad/js/internalModules.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line no-unused-vars
-import promisify from 'agent-base/dist/src/promisify';
+import picka from '@next/eslint-plugin-next/lib/index';

--- a/src/__tests__/bad/ts/internalModules.ts
+++ b/src/__tests__/bad/ts/internalModules.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import promisify from 'agent-base/dist/src/promisify';
+import picka from '@next/eslint-plugin-next/lib/index';

--- a/src/__tests__/bad/ts/internalModules.ts
+++ b/src/__tests__/bad/ts/internalModules.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import picka from '@next/eslint-plugin-next/lib/index';
+import promisify from 'agent-base/dist/src/promisify';

--- a/src/__tests__/bad/ts/internalModules.ts
+++ b/src/__tests__/bad/ts/internalModules.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import picka from '@next/eslint-plugin-next/lib/index';

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -8,19 +8,19 @@ const testConfigs = [
   {
     eslintFilePath: `${testDir}/.eslintrc.js`,
     good: 0,
-    bad: 16,
+    bad: 17,
     filePattern: '{js,ts}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.react.js`,
     good: 6,
-    bad: 28,
+    bad: 29,
     filePattern: '{js,ts,jsx,tsx}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.next.js`,
     good: 0,
-    bad: 28,
+    bad: 29,
     filePattern: '{js,ts,jsx,tsx}',
   },
 ];

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -8,19 +8,19 @@ const testConfigs = [
   {
     eslintFilePath: `${testDir}/.eslintrc.js`,
     good: 0,
-    bad: 17,
+    bad: 16,
     filePattern: '{js,ts}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.react.js`,
     good: 6,
-    bad: 29,
+    bad: 28,
     filePattern: '{js,ts,jsx,tsx}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.next.js`,
     good: 0,
-    bad: 29,
+    bad: 28,
     filePattern: '{js,ts,jsx,tsx}',
   },
 ];

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -8,19 +8,19 @@ const testConfigs = [
   {
     eslintFilePath: `${testDir}/.eslintrc.js`,
     good: 0,
-    bad: 17,
+    bad: 14,
     filePattern: '{js,ts}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.react.js`,
     good: 6,
-    bad: 29,
+    bad: 26,
     filePattern: '{js,ts,jsx,tsx}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.next.js`,
     good: 0,
-    bad: 29,
+    bad: 26,
     filePattern: '{js,ts,jsx,tsx}',
   },
 ];

--- a/src/index.js
+++ b/src/index.js
@@ -120,12 +120,7 @@ module.exports = {
   ],
   rules: {
     'no-console': 'error',
-    'import/no-internal-modules': [
-      'error',
-      {
-        forbid: ['*/dist/**', '*/dist'],
-      },
-    ],
+    'import/no-internal-modules': 'error',
     'import/order': [
       'error',
       {

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ module.exports = {
     'import/no-internal-modules': [
       'error',
       {
-        forbid: ['@*/**'],
+        allow: ['*/*'],
       },
     ],
     'import/order': [

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
@@ -120,7 +119,6 @@ module.exports = {
   ],
   rules: {
     'no-console': 'error',
-    'import/no-internal-modules': 'error',
     'import/order': [
       'error',
       {

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ module.exports = {
     'import/no-internal-modules': [
       'error',
       {
-        forbid: ['external'],
+        forbid: ['@*/**'],
       },
     ],
     'import/order': [

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,12 @@ module.exports = {
   ],
   rules: {
     'no-console': 'error',
-    'import/no-internal-modules': 'error',
+    'import/no-internal-modules': [
+      'error',
+      {
+        forbid: ['external'],
+      },
+    ],
     'import/order': [
       'error',
       {

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ module.exports = {
     'import/no-internal-modules': [
       'error',
       {
-        allow: ['*/*'],
+        forbid: ['*/dist/**', '*/dist'],
       },
     ],
     'import/order': [

--- a/src/next.js
+++ b/src/next.js
@@ -40,7 +40,7 @@ module.exports = {
     'import/no-internal-modules': [
       'error',
       {
-        allow: ['*/*'],
+        allow: ['*/*', '@testing-library/**/*'],
       },
     ],
   },

--- a/src/next.js
+++ b/src/next.js
@@ -40,7 +40,7 @@ module.exports = {
     'import/no-internal-modules': [
       'error',
       {
-        allow: ['next/*', '@testing-library/**/*', 'react-dom/*', '**/*.css'],
+        forbid: ['external'],
       },
     ],
   },

--- a/src/next.js
+++ b/src/next.js
@@ -40,7 +40,7 @@ module.exports = {
     'import/no-internal-modules': [
       'error',
       {
-        forbid: ['external'],
+        forbid: ['@*/**'],
       },
     ],
   },

--- a/src/next.js
+++ b/src/next.js
@@ -36,16 +36,4 @@ module.exports = {
       },
     },
   ],
-  rules: {
-    'import/no-internal-modules': [
-      'error',
-      {
-        allow: [
-          'next/*',
-          '@testing-library/**',
-          '**/+(config|components|types)/**',
-        ],
-      },
-    ],
-  },
 };

--- a/src/next.js
+++ b/src/next.js
@@ -40,7 +40,11 @@ module.exports = {
     'import/no-internal-modules': [
       'error',
       {
-        forbid: ['*/dist/**', '*/dist'],
+        allow: [
+          'next/*',
+          '@testing-library/**',
+          '**/+(config|components|types)/**',
+        ],
       },
     ],
   },

--- a/src/next.js
+++ b/src/next.js
@@ -40,7 +40,7 @@ module.exports = {
     'import/no-internal-modules': [
       'error',
       {
-        allow: ['*/*', '@testing-library/**/*'],
+        forbid: ['*/dist/**', '*/dist'],
       },
     ],
   },

--- a/src/next.js
+++ b/src/next.js
@@ -37,10 +37,10 @@ module.exports = {
     },
   ],
   rules: {
-    'import/no-internal-modules': [
+    'no-restricted-imports': [
       'error',
       {
-        forbid: ['@*/**'],
+        allow: ['*/*'],
       },
     ],
   },

--- a/src/next.js
+++ b/src/next.js
@@ -37,7 +37,7 @@ module.exports = {
     },
   ],
   rules: {
-    'no-restricted-imports': [
+    'import/no-internal-modules': [
       'error',
       {
         allow: ['*/*'],


### PR DESCRIPTION
[FE-79](https://autoricardo.atlassian.net/browse/FE-79?atlOrigin=eyJpIjoiN2ZmMTk3NzlmNjkzNDg0ZGE3Yjc0ZjM1Y2UyNTQ1MjUiLCJwIjoiaiJ9)

## Motivation and context

We agreed to keep the rule for external modules (i.e. dependencies), but relax the restrictions on the internal modules.

## Before

Not possible to import submodules

## After

Possible to import submodules, except for external packages


