### PR TITLE
feat: ban parent imports

### DIFF
--- a/src/__tests__/bad/js/parentImport.js
+++ b/src/__tests__/bad/js/parentImport.js
@@ -1,0 +1,3 @@
+import { logInfo } from '../../utils';
+
+logInfo('test');

--- a/src/__tests__/bad/ts/parentImport.ts
+++ b/src/__tests__/bad/ts/parentImport.ts
@@ -1,0 +1,3 @@
+import { logInfo } from '../../utils';
+
+logInfo('test');

--- a/src/__tests__/good/js/parentImport.js
+++ b/src/__tests__/good/js/parentImport.js
@@ -1,0 +1,3 @@
+import { yo } from '../js/semicolons';
+
+const _foo = yo + 1;

--- a/src/__tests__/good/js/semicolons.js
+++ b/src/__tests__/good/js/semicolons.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line no-unused-vars
-const _yo = true;
+export const yo = 4;

--- a/src/__tests__/good/ts/parentImport.ts
+++ b/src/__tests__/good/ts/parentImport.ts
@@ -1,0 +1,3 @@
+import { yo } from '../ts/semicolons';
+
+const _foo = yo + 1;

--- a/src/__tests__/good/ts/semicolons.ts
+++ b/src/__tests__/good/ts/semicolons.ts
@@ -1,1 +1,1 @@
-const _yo = true;
+export const yo = 3;

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -8,19 +8,19 @@ const testConfigs = [
   {
     eslintFilePath: `${testDir}/.eslintrc.js`,
     good: 0,
-    bad: 14,
+    bad: 16,
     filePattern: '{js,ts}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.react.js`,
     good: 6,
-    bad: 26,
+    bad: 28,
     filePattern: '{js,ts,jsx,tsx}',
   },
   {
     eslintFilePath: `${testDir}/.eslintrc.next.js`,
     good: 0,
-    bad: 26,
+    bad: 28,
     filePattern: '{js,ts,jsx,tsx}',
   },
 ];

--- a/src/index.js
+++ b/src/index.js
@@ -156,5 +156,16 @@ module.exports = {
     ],
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': 'error',
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['../../*'],
+            message: 'Usage of relative parent imports is not allowed.',
+          },
+        ],
+      },
+    ],
   },
 };


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/FE-121

## Motivation and context

To enforce usage of `baseUrl` and absolute imports we introduce a rule to prevent nested imports from the parent