### PR TITLE
fix: disable linter warning for tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,12 +33,7 @@ module.exports = {
       ],
       rules: {
         'sonarjs/no-duplicate-string': 'off',
-      },
-    },
-    {
-      files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)*'],
-      rules: {
-        'import/no-named-as-default': 0,
+        'import/no-named-as-default': 'off',
       },
     },
     {

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,12 @@ module.exports = {
       },
     },
     {
+      files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)*'],
+      rules: {
+        'import/no-named-as-default': 0,
+      },
+    },
+    {
       files: ['*.ts', '*.js'],
       rules: {
         'unicorn/filename-case': [


### PR DESCRIPTION
References [JIRA ticket](https://autoricardo.atlassian.net/browse/FE-183)

## Motivation and context

Linter is showing warnings for tests 3rd party package `@testing-library/user-event`. Instead of `default` export of the module, this package exports a named export called `default`.

## Before

Running linter shows warnings for test files: `warning  Using exported name 'userEvent' as identifier for default export  import/no-named-as-default`.

## After

Running linter doesn't show `import/no-named-as-default` warnings for test files.

## How to test

Affected repos: seller-web, listings-web, next-example, components-pkg.

Run linter and confirm warnings are showing up. As change is a small one, you might apply it directly and re-run the linter. After the PR merge and `eslint-config-pkg` version bump, re-test all the affected repos.
