### PR TITLE
fix: disable no-duplicate-string rule for json files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ module.exports = {
         '**/__tests__/**/*.[jt]s?(x)',
         '**/?(*.)+(spec|test).[tj]s?(x)*',
         'package-lock.json',
+        '*.json',
         '**/config/**',
         '**/cypress/**',
       ],


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

[Describe the problem we're solving and lay out the solution]

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
