### PR TITLE
fix: extend eslint naming convention rule

### DIFF
--- a/src/__tests__/.eslintrc.next.js
+++ b/src/__tests__/.eslintrc.next.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 module.exports = {
   extends: ['../../src/next.js'],
   rules: {

--- a/src/index.js
+++ b/src/index.js
@@ -101,8 +101,8 @@ module.exports = {
           },
           {
             selector: 'property',
-            format: ['camelCase', 'snake_case', 'PascalCase'],
-            leadingUnderscore: 'allow',
+            format: ['camelCase', 'snake_case', 'PascalCase', 'UPPER_CASE'],
+            leadingUnderscore: 'allowSingleOrDouble',
           },
           {
             selector: 'typeLike',


### PR DESCRIPTION
References [JIRA](https://smg-au.atlassian.net/browse/FE-202)

## Motivation and context

We need to extend ESLint `naming-convention` rule in order to delete disabled ESLint rules across apps and packages.

## Before

ESLint doesn't allow uppercase property names and double leading underscores.

## After

ESLint allows uppercase property names and double leading underscores.

## How to test

Can be tested from other packages that are using this package, and with removal of the existing `eslint-disable @typescript-eslint/naming-convention` rules.
