### PR TITLE
fix: extend eslint rule for variableLike selector

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ module.exports = {
           },
           {
             selector: 'variableLike',
-            format: ['camelCase', 'PascalCase'],
+            format: ['camelCase', 'PascalCase', 'snake_case'],
             leadingUnderscore: 'allow',
           },
           {


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/IN-1709
## Motivation and context

To be able to utilise common shared packages as much as possible and remove disabled ESLint rules for naming-convention in Auth package we need to extend rule for variableLike selector.

## Before

snake_case format is not included in variableLike selector.

## After

snake_case format is included in variableLike selector.

## Note

This PR is created again because previous was not released. I suppose it happened because of the merge title.
