### PR TITLE
fix: folder naming convention

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -128,7 +128,8 @@ export default [
     },
   },
   {
-    files: ['**/*.ts', '**/*.js'],
+    files: ['**/*', '**/*.ts', '**/*.js'],
+    excludedFiles: ['**/pages/**/*', '**/helm-chart/**/*'],
     rules: {
       'unicorn/filename-case': [
         'error',

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -129,7 +129,6 @@ export default [
   },
   {
     files: ['**/*', '**/*.ts', '**/*.js'],
-    excludedFiles: ['**/pages/**/*', '**/helm-chart/**/*'],
     rules: {
       'unicorn/filename-case': [
         'error',
@@ -139,6 +138,12 @@ export default [
           },
         },
       ],
+    },
+  },
+  {
+    files: ['**/pages/**/*', '**/helm-chart/**/*'],
+    rules: {
+      'unicorn/filename-case': 'off',
     },
   },
   {


### PR DESCRIPTION
References [PS-87](https://smg-au.atlassian.net/browse/PS-87)

## Motivation and context

We want to add a rule to be sure that all folders in our projects use camelCase naming convention (except pages and helm-chart folders).

## Before

We don't have a rule for camelCase folder naming convention.

## After

We have a rule for camelCase folder naming convention and a rule for excluding pages and helm-chart folders.

[PS-87]: https://smg-au.atlassian.net/browse/PS-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ