### PR TITLE
feat: ignoring package-lock file

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -13,7 +13,7 @@ export default [
   ...tseslint.configs.recommended,
   sonarjs.configs.recommended,
   {
-    ignores: ['dist', 'coverage/*'],
+    ignores: ['dist', 'coverage/*', 'package-lock.json'],
   },
   {
     languageOptions: {


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Ignoring the autogenerated `package-lock.json` file, since we don’t control its contents and there is no point in linting it. I also encountered issues with it, as the Sonar check returned errors for that file.

<img width="854" height="61" alt="Screenshot 2025-08-04 at 10 07 22" src="https://github.com/user-attachments/assets/d4347ade-d324-4f08-a94a-cd9998b16fa5" />

<img width="466" height="36" alt="Screenshot 2025-08-04 at 10 07 39" src="https://github.com/user-attachments/assets/7b69d87f-765d-49e2-a0e9-34506adb191d" />

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
