### PR TITLE
[codex] add monorepo migration banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # SMG-Automotive ESLint Config
 
+> [!IMPORTANT]
+> This project is being migrated into [smg-automotive/automotive-web](https://github.com/smg-automotive/automotive-web/). Please check the monorepo before starting new work in this repository.
+
 ## Usage
 
 ```shell


### PR DESCRIPTION
## Summary
- Add a README banner noting the ongoing migration to `smg-automotive/automotive-web`.
- Link readers to https://github.com/smg-automotive/automotive-web/ before starting new work in this repository.

## Validation
- README-only change; no tests run.