### PR TITLE
feat: require post method on JSX forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ export default [
 - For React project, use `"@smg-automotive/eslint-config/react"`
 - For Next.js project, use `"@smg-automotive/eslint-config/next"`
 
+The React and Next.js configs require JSX forms to explicitly set `method="post"` to prevent the native browser GET fallback from exposing form values in the URL.
+
 ### EditorConfig configuration
 
 Create/Update your `.editorconfig` by [this content](https://github.com/smg-automotive/eslint-config-pkg/blob/main/.editorconfig).

--- a/src/__tests__/bad/ts/FormMethod.tsx
+++ b/src/__tests__/bad/ts/FormMethod.tsx
@@ -1,0 +1,17 @@
+const MissingMethodForm = () => (
+  <form>
+    <label htmlFor="email">Email</label>
+    <input id="email" name="email" />
+    <button type="submit">Submit</button>
+  </form>
+);
+
+const GetMethodForm = () => (
+  <form method="get">
+    <label htmlFor="query">Search</label>
+    <input id="query" name="query" />
+    <button type="submit">Search</button>
+  </form>
+);
+
+export { GetMethodForm, MissingMethodForm };

--- a/src/__tests__/good/ts/FormMethod.tsx
+++ b/src/__tests__/good/ts/FormMethod.tsx
@@ -1,0 +1,9 @@
+const ContactForm = () => (
+  <form method="post">
+    <label htmlFor="email">Email</label>
+    <input id="email" name="email" />
+    <button type="submit">Submit</button>
+  </form>
+);
+
+export default ContactForm;

--- a/src/__tests__/test.mjs
+++ b/src/__tests__/test.mjs
@@ -15,13 +15,13 @@ const testConfigs = [
     eslintFilePath: `${testDir}/eslint.react.mjs`,
     // the 6 expected 'good' examples are thrown in pages since it's nextjs related
     good: 6,
-    bad: 27,
+    bad: 29,
     filePattern: '{js,ts,jsx,tsx}',
   },
   {
     eslintFilePath: `${testDir}/eslint.next.mjs`,
     good: 0,
-    bad: 29,
+    bad: 31,
     filePattern: '{js,ts,jsx,tsx}',
   },
 ];

--- a/src/react.mjs
+++ b/src/react.mjs
@@ -49,6 +49,21 @@ export default [
   {
     files: ['**/*.tsx', '**/*.jsx'],
     rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "JSXOpeningElement[name.name='form']:not(:has(JSXAttribute[name.name='method']))",
+          message:
+            'Forms must explicitly set method="post" to avoid the native browser GET fallback.',
+        },
+        {
+          selector:
+            "JSXOpeningElement[name.name='form'] > JSXAttribute[name.name='method']:not([value.type='Literal'][value.value='post'])",
+          message:
+            'Forms must explicitly set method="post" to avoid the native browser GET fallback.',
+        },
+      ],
       'unicorn/filename-case': [
         'error',
         {


### PR DESCRIPTION
References https://github.com/smg-automotive/listings-web/pull/4465

## Motivation and context

Prevent React and Next.js consumers from accidentally relying on the native browser form default. A JSX `<form>` without an explicit method falls back to GET when JavaScript submit handling does not run, which can expose submitted form values in the URL.

This adds an ESLint `no-restricted-syntax` rule to the shared React config. The Next config extends the React config, so Next.js consumers get the same behavior.

## Before

The shared React and Next.js configs allowed JSX forms with omitted methods or explicit non-POST methods, for example `<form>` or `<form method="get">`.

## After

JSX forms must explicitly use `method="post"`. Omitted methods, `method="get"`, and non-literal method values produce ESLint errors. Good and bad fixtures cover the new behavior, and the README documents the rule.

## How to test

- `npm test`
- `npm run lint`